### PR TITLE
Manager `struct` and upgraded `stores`

### DIFF
--- a/aika/src/environment.rs
+++ b/aika/src/environment.rs
@@ -7,7 +7,7 @@ use rand::SeedableRng;
 
 use crate::distribution::Distribution;
 use std::cmp::Reverse;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::{BTreeMap, BinaryHeap, HashMap};
 use std::ops::{Generator, GeneratorState};
 use std::pin::Pin;
 
@@ -95,7 +95,7 @@ pub struct Environment<T> {
     /// The maximum event time.
     pub max_event: u64,
     /// The stores of the simulation yield.
-    pub stores: Vec<(u64, T)>,
+    pub stores: BTreeMap<u64, T>,
     /// Seeded random number generator for optional randomness.
     pub rng: rand::rngs::StdRng,
 }
@@ -108,7 +108,7 @@ impl<T> Environment<T> {
             processes: HashMap::new(),
             curr_event: 0,
             max_event: max_event,
-            stores: Vec::new(),
+            stores: BTreeMap::new(),
             rng: rand::rngs::StdRng::seed_from_u64(seed),
         }
     }
@@ -172,7 +172,7 @@ impl<T> Environment<T> {
         match process.resume(()) {
             GeneratorState::Yielded(val) => {
                 self.add_events(process_id, time_delta);
-                self.stores.push((self.curr_event, val));
+                self.stores.insert(self.curr_event, val);
                 self.curr_event += 1;
             }
             GeneratorState::Complete(_output) => {}
@@ -186,7 +186,7 @@ impl<T> Environment<T> {
                 self.step();
             }
         } else {
-            println!("✅ Simulation complete ✅");
+            return;
         }
     }
 

--- a/aika/src/lib.rs
+++ b/aika/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod distribution;
 pub mod environment;
+pub mod manager;
 
 #[cfg(test)]
 mod test {

--- a/aika/src/manager.rs
+++ b/aika/src/manager.rs
@@ -1,0 +1,34 @@
+use std::collections::BTreeMap;
+
+use crate::environment::Environment;
+
+/// The `Manager` struct is responsible for running a series of simulations and storing the results.
+pub struct Manager<T: Clone> {
+    /// The number of simulations to run.
+    pub simulations: Vec<Environment<T>>,
+    /// The storage of simulation data
+    pub stores: Vec<BTreeMap<u64, T>>,
+}
+
+impl<T: Clone> Manager<T> {
+    /// Create a new `Manager` struct.
+    pub fn new() -> Self {
+        Manager {
+            simulations: Vec::new(),
+            stores: Vec::new(),
+        }
+    }
+
+    /// Add a simulation to the `Manager` struct.
+    pub fn add_simulation(&mut self, simulation: Environment<T>) {
+        self.simulations.push(simulation);
+    }
+
+    /// Run all simulations in the `Manager` struct.
+    pub fn run(&mut self) {
+        for simulation in &mut self.simulations {
+            simulation.run();
+            self.stores.push(simulation.stores.clone());
+        }
+    }
+}


### PR DESCRIPTION
Closes #9 and closes #10. Requires the yield of processes be the state of the system you wish to track